### PR TITLE
Change 'score' to unsigned integer type (per John Barnes, University of Kentucky)

### DIFF
--- a/ArenaControl/ArenaControl.ino
+++ b/ArenaControl/ArenaControl.ino
@@ -206,7 +206,7 @@ void endCompetition() {
    // Calculate and print out the score - 10 points for each one
    //   sequenced correctly, plus 1 point (max of 100) for those not
    //   sequenced correctly
-   int score = (numSequenced * 10) + min(extraNotSequenced, 100);
+   unsigned int score = (numSequenced * 10) + min(extraNotSequenced, 100);
    Serial.print(F("\nFinal score: "));
    Serial.println(score);
    


### PR DESCRIPTION
Per John Barnes (University of Kentucky), max button score can potentially overflow to a value of 36000, exceeding the maximum value of a 32767.

Original issue:
"I just found a bug in ArenaControl.ino about line 209.  score is defined as an int, with a range of -32768 to 32767.  The 25ms on, 25ms off timing of the pushbuttons would allow a robot to push up to 20 buttons per second.  Over 180 seconds (3 minutes), that would be 3600 digits of pi.  At 10 points per correct digit, that comes to a maximum possible score of 36000-- overflowing an int variable.  score should be declared as a long, unsigned long, or at least an unsigned int."